### PR TITLE
Specify dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,9 @@ setup(
     zip_safe = False,
     include_package_data = True,
     packages=find_packages(),
-    install_requires=['thumbor','botornado']
+    install_requires=[
+        'thumbor>=4.0.0,<5.0.0',
+        'tornado>2.3.0,<4.0.0',
+        'botornado==0.0.3',
+    ]
 )


### PR DESCRIPTION
The recent release of thumbor 5.0.0 breaks this package. This change locks thumbor to 4.x. It also species the version of tornado required by thumbor 4.x, which seems to be ignored in favour of the looser version required by botornado.