### PR TITLE
Support Thumbor 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'thumbor_botornado',
-    version = "0.1",
+    version = "2.0.0",
     description = 'Thumbor S3 integration via botornado',
     author = 'Paul Annesley',
     author_email = 'paul@99designs.com',
@@ -10,8 +10,7 @@ setup(
     include_package_data = True,
     packages=find_packages(),
     install_requires=[
-        'thumbor>=4.0.0,<5.0.0',
-        'tornado>2.3.0,<4.0.0',
+        'thumbor>=5.0.0',
         'botornado==0.0.3',
     ]
 )

--- a/thumbor_botornado/s3_loader.py
+++ b/thumbor_botornado/s3_loader.py
@@ -1,7 +1,9 @@
 from botornado.s3.bucket import AsyncBucket
 from botornado.s3.connection import AsyncS3Connection
 from botornado.s3.key import AsyncKey
+from tornado.concurrent import return_future
 
+@return_future
 def load(context, url, callback):
     bucket_name, object_name = url.split("/", 1)
     connection = AsyncS3Connection() # load credentials from environment


### PR DESCRIPTION
[Thumbor 5 was released a month ago](https://github.com/thumbor/thumbor/releases/tag/5.0.0) with breaking changes in the storage/loader interface, which `thumbor_botornado` hooks into.

`thumbor_botornado` needs to be pinned to Thumbor 4 and a new major release (likely `v2.0.0`) is required to replace the old callback interface with the new “futures” interface.

/cc @harto

- [x] Pin `thumbor_botornado` 1.x to Thumbor 4 (https://github.com/99designs/thumbor_botornado/pull/7, https://github.com/99designs/thumbor_botornado/releases/tag/v1.0.1)
    - i.e. `thumbor<5.0.0`
- [ ] Release `thumbor_botornado` 2.x compatible with Thumbor 5
    - i.e. `thumbor>=5.0.0`, no need for backwards compatibility.