### PR TITLE
Fix import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/thumbor_botornado/s3_http_loader.py
+++ b/thumbor_botornado/s3_http_loader.py
@@ -1,6 +1,6 @@
 import thumbor_botornado.s3_loader as S3Loader
-import tornado.concurrent.return_future
 import thumbor.loaders.http_loader as HttpLoader
+from tornado.concurrent import return_future
 import re
 
 HTTP_RE = re.compile(r'\Ahttps?:', re.IGNORECASE)


### PR DESCRIPTION
using `s3_http_loader.rb` in thumbor results in an error:

``` bash
Traceback (most recent call last):
  File "thumbor_botornado/s3_http_loader.py", line 2, in <module>
    import tornado.concurrent.return_future
ImportError: No module named return_future
```

so i changed the import to be the same as in `s3_loader.py`
